### PR TITLE
Use PyPI OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,20 +6,24 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/omfvista
+    permissions:
+      id-token: write # this permission is mandatory for trusted publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
-      - name: Install dependencies
+          python-version: "3.12"
+      - name: Install build
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-      - name: Build and Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload --skip-existing dist/*
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,13 +30,6 @@ jobs:
           pip install -e .
           pip install -r requirements.txt
       - name: Test
-        run: |
-          pytest -v --cov=omfvista .
-          coverage xml -o coverage.xml
+        run: pytest -v .
       - name: Test notebook
         run: pytest -v --nbval-lax --current-env --disable-warnings Example.ipynb
-      - uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
-          verbose: true

--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,6 @@ Open Mining Format: PyVista (VTK) Interface
    :target: https://pypi.org/project/omfvista/
    :alt: PyPI
 
-.. image:: https://codecov.io/gh/OpenGeoVis/omfvista/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/OpenGeoVis/omfvista
-
 .. image:: https://img.shields.io/github/stars/OpenGeoVis/omfvista.svg?style=social&label=Stars
    :target: https://github.com/OpenGeoVis/omfvista
    :alt: GitHub


### PR DESCRIPTION
## Summary

Migrate release workflow from PyPI API token auth (via `twine upload`) to OIDC Trusted Publishing using `pypa/gh-action-pypi-publish`. Replaces `python setup.py sdist bdist_wheel` with `python -m build`, adds `permissions: id-token: write` and `environment: pypi`.

## Next steps

- [ ] Add a Trusted Publisher on PyPI for this project: Account → Publishing → Add a new publisher (workflow: `release.yaml`, environment: `pypi`).
- [ ] Add `omfvista` to the `pyvista` PyPI organization.
- [ ] After first successful OIDC release, delete the old PyPI API token and revoke the `PYPI_API_TOKEN` Actions secret.